### PR TITLE
Mitigate issues with state locking

### DIFF
--- a/manifests/base/terraform-applier.yaml
+++ b/manifests/base/terraform-applier.yaml
@@ -23,16 +23,15 @@ spec:
     app: terraform-applier
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: terraform-applier
 spec:
   replicas: 1
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       app: terraform-applier
+  serviceName: terraform-applier
   template:
     metadata:
       labels:

--- a/manifests/base/terraform-applier.yaml
+++ b/manifests/base/terraform-applier.yaml
@@ -28,6 +28,8 @@ metadata:
   name: terraform-applier
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: terraform-applier

--- a/manifests/example/terraform-applier-patch.yaml
+++ b/manifests/example/terraform-applier-patch.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: terraform-applier
 spec:

--- a/run/runner.go
+++ b/run/runner.go
@@ -22,6 +22,8 @@ type Runner struct {
 	RepoPathFilters []string
 	RunResults      chan<- Result
 	RunQueue        <-chan bool
+
+	applying bool
 }
 
 // Start runs a continuous loop that starts a new run when a request comes into the queue channel.
@@ -36,10 +38,18 @@ func (r *Runner) Start() {
 	}
 }
 
+func (r *Runner) Applying() bool {
+	return r.applying
+}
+
 // Run performs a full apply run, and returns a Result with data about the completed run (or nil if the run failed to complete).
 func (r *Runner) run() (*Result, error) {
-
 	log.Info("Started apply run")
+
+	r.applying = true
+	defer func() {
+		r.applying = false
+	}()
 
 	dirs, err := sysutil.ListDirs(r.RepoPath)
 	if err != nil {


### PR DESCRIPTION
- Wait for apply runs to finish when SIGINT or SIGTERM is received. Exit immediately when a second signal is received, primarily to prevent holding the terminal hostage when running locally.
- Use `spec.strategy.type=Recreate` to ensure only one applier is running at one time