### PR TITLE
Fix bases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ update-jquery-js:
 	curl -o static/bootstrap/js/jquery.min.js https://code.jquery.com/jquery-3.6.0.min.js
 
 release:
-	@sd "latest" "$(VERSION)" manifests/base/terraform-applier.yaml
+	@sd "master" "$(VERSION)" manifests/base/terraform-applier.yaml
+	@sd "master" "$(VERSION)" manifests/git-sync/terraform-applier.yaml
 	@git add -- manifests/base/terraform-applier.yaml
 	@git commit -m "Release $(VERSION)"
-	@sd "$(VERSION)" "latest" manifests/base/terraform-applier.yaml
+	@sd "$(VERSION)" "master" manifests/base/terraform-applier.yaml
+	@sd "$(VERSION)" "master" manifests/git-sync/terraform-applier.yaml
 	@git add -- manifests/base/terraform-applier.yaml
 	@git commit -m "Clean up release $(VERSION)"

--- a/manifests/base/terraform-applier.yaml
+++ b/manifests/base/terraform-applier.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: terraform-applier
       containers:
         - name: terraform-applier
-          image: quay.io/utilitywarehouse/terraform-applier:latest
+          image: quay.io/utilitywarehouse/terraform-applier:master
           resources:
             requests:
               cpu: 10m
@@ -50,3 +50,6 @@ spec:
               memory: 200Mi
           ports:
             - containerPort: 8080
+          env:
+            - name: MODULES_PATH
+              value: /src

--- a/manifests/examples/configmap/terraform-applier-patch.yaml
+++ b/manifests/examples/configmap/terraform-applier-patch.yaml
@@ -8,9 +8,7 @@ spec:
       containers:
         - name: terraform-applier
           env:
-            - name: MODULES_PATH
-              value: "/src/modules"
-            # Variables from now depend on what terraform providers and resources you use
+            # Variables depend on what terraform providers and resources you use
             #
             # For instance, the environment variables below configure the
             # Kubernetes secret backend to use the in cluster config and the
@@ -23,9 +21,9 @@ spec:
                   fieldPath: metadata.namespace
           volumeMounts:
             - name: module1
-              mountPath: "/src/modules/module1"
+              mountPath: "/src/module1"
             - name: module2
-              mountPath: "/src/modules/module2"
+              mountPath: "/src/module2"
       volumes:
         - name: module1
           configMap:

--- a/manifests/git-sync/kustomization.yaml
+++ b/manifests/git-sync/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base
-patchesStrategicMerge:
   - terraform-applier.yaml

--- a/manifests/git-sync/terraform-applier.yaml
+++ b/manifests/git-sync/terraform-applier.yaml
@@ -1,11 +1,62 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terraform-applier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /__/metrics
+    prometheus.io/port: "8080"
+  name: terraform-applier
+  labels:
+    app: terraform-applier
+spec:
+  ports:
+    - name: web
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+  selector:
+    app: terraform-applier
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: terraform-applier
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: terraform-applier
+  serviceName: terraform-applier
   template:
+    metadata:
+      labels:
+        app: terraform-applier
     spec:
+      serviceAccountName: terraform-applier
       containers:
+        - name: terraform-applier
+          image: quay.io/utilitywarehouse/terraform-applier:master
+          resources:
+            requests:
+              cpu: 10m
+              memory: 25Mi
+            limits:
+              cpu: 500m
+              memory: 200Mi
+          ports:
+            - containerPort: 8080
+          env:
+            - name: MODULES_PATH
+              value: /src
+          volumeMounts:
+            - name: git-repo
+              mountPath: /src
+              readOnly: true
         - name: git-sync
           image: k8s.gcr.io/git-sync/git-sync:v3.3.0
           securityContext:
@@ -32,11 +83,6 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
-        - name: terraform-applier
-          volumeMounts:
-            - name: git-repo
-              mountPath: /src
-              readOnly: true
       volumes:
         - name: git-repo
           emptyDir: {}


### PR DESCRIPTION
- It seems you can't pull a base remotely if it's making relative references like `../base`.
- By default provide the 'master' image from the 'master' branch; we've recently changed our CI process so that latest != master
- Add an expected `MODULES_PATH` of `/src`