### PR TITLE
gh action: build on all branch pushes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - "master"
+      - "*"
     tags:
       - "v*"
   pull_request:


### PR DESCRIPTION
It's useful to run the tests and produce an image that can be pulled in exp environments before logging a PR.