### PR TITLE
Cosmetic improvements

### DIFF
--- a/run/applier.go
+++ b/run/applier.go
@@ -120,7 +120,7 @@ func (l *tfLogger) Printf(format string, v ...interface{}) {
 	log.Info("+ %s", msg)
 	// Write the command to the output with a faux shell prompt and a new
 	// line at the end. This aids readability.
-	fmt.Fprint(l.w, "$ "+msg+"\n")
+	fmt.Fprint(l.w, fmt.Sprintf("\n$ %s\n", msg))
 }
 
 func (a *Applier) applyModule(ctx context.Context, modulePath string) (string, error) {

--- a/static/stylesheets/main.css
+++ b/static/stylesheets/main.css
@@ -1,5 +1,4 @@
 pre.file-output {
-	font-family: Monaco;
 	font-size: 10px;
 }
 


### PR DESCRIPTION
- Don't specify a font-family for `file-output`. This panel seems to render better across different systems without a specific font-family that may or may not be available.
- Add a newline before writing the terraform command to the output. This results in better spacing that's more visually pleasing to me on the UI.
![Screenshot from 2021-08-20 15-50-29](https://user-images.githubusercontent.com/9870923/130251885-23bfb3e8-ee60-4faa-859f-94b37e9fd9bd.png)
