### PR TITLE
metrics: add terraform_applier_module_apply_success

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ terraform-applier exports Prometheus metrics. The metrics are hosted on the webs
 
 In addition to the Prometheus default metrics, the following custom metrics are included:
 
-- `module_apply_count` - (tags: `module`, `success`) A Counter for each module that has had an apply attempt over the lifetime of
+- `terraform_applier_module_apply_count` - (tags: `module`, `success`) A Counter for each module that has had an apply attempt over the lifetime of
   the application, incremented with each apply attempt and tagged with the result of the run (`success=true|false`)
-- `module_apply_duration_seconds` - (tags: `module`, `success`) A Summary that keeps track of the durations of each apply run for
+- `terraform_applier_module_apply_duration_seconds` - (tags: `module`, `success`) A Summary that keeps track of the durations of each apply run for
   each module, tagged with the result of the run (`success=true|false`)
-- `terraform_exit_code_count` - (tags: `module`, `command`, `exit_code`) A `Counter` for each exit code returned by executions of
+- `terraform_applier_terraform_exit_code_count` - (tags: `module`, `command`, `exit_code`) A `Counter` for each exit code returned by executions of
   `terraform`, labelled with the command issued (`init`, `plan`,`apply`) and the exit code. It's worth noting that `plan` will
   return a code of `2` if there are changes to be made, which is not an error or a failure, so you may wish to account for this in your alerting.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ In addition to the Prometheus default metrics, the following custom metrics are 
   the application, incremented with each apply attempt and tagged with the result of the run (`success=true|false`)
 - `terraform_applier_module_apply_duration_seconds` - (tags: `module`, `success`) A Summary that keeps track of the durations of each apply run for
   each module, tagged with the result of the run (`success=true|false`)
+- `terraform_applier_module_apply_success` - (tags: `module`) A `Gauge` which
+  tracks whether the last apply run for a module was successful.
 - `terraform_applier_terraform_exit_code_count` - (tags: `module`, `command`, `exit_code`) A `Counter` for each exit code returned by executions of
   `terraform`, labelled with the command issued (`init`, `plan`,`apply`) and the exit code. It's worth noting that `plan` will
   return a code of `2` if there are changes to be made, which is not an error or a failure, so you may wish to account for this in your alerting.

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -7,6 +7,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	metricsNamespace = "terraform_applier"
+)
+
 // PrometheusInterface allows for mocking out the functionality of Prometheus when testing the full process of an apply run.
 type PrometheusInterface interface {
 	UpdateTerraformExitCodeCount(string, string, int)
@@ -28,8 +32,9 @@ type Prometheus struct {
 func (p *Prometheus) Init() {
 
 	p.moduleApplyCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "module_apply_count",
-		Help: "Success metric for every module applied",
+		Namespace: metricsNamespace,
+		Name:      "module_apply_count",
+		Help:      "Success metric for every module applied",
 	},
 		[]string{
 			// Path of the module that was applied
@@ -39,8 +44,9 @@ func (p *Prometheus) Init() {
 		},
 	)
 	p.moduleApplyDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "module_apply_duration_seconds",
-		Help: "Duration of the apply runs",
+		Namespace: metricsNamespace,
+		Name:      "module_apply_duration_seconds",
+		Help:      "Duration of the apply runs",
 	},
 		[]string{
 			// Path of the module that was applied
@@ -50,8 +56,9 @@ func (p *Prometheus) Init() {
 		},
 	)
 	p.terraformExitCodeCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "terraform_exit_code_count",
-		Help: "Count of terraform exit codes",
+		Namespace: metricsNamespace,
+		Name:      "terraform_exit_code_count",
+		Help:      "Count of terraform exit codes",
 	},
 		[]string{
 			// Path of the module that was applied


### PR DESCRIPTION
Add a gauge that tracks the status of the last apply run of a module.

This provides a more concrete way of alerting on the 'status' of a module than trying to leverage the apply count.

Also add a namespace to the front of all the metrics so they're grouped together and it's obvious what application they're produced by.