### PR TITLE
Request some ephemeral-storage to avoid evictions

### DIFF
--- a/manifests/base/namespaced/tf-applier.yaml
+++ b/manifests/base/namespaced/tf-applier.yaml
@@ -60,9 +60,11 @@ spec:
             limits:
               cpu: 2000m
               memory: 2Gi
+              ephemeral-storage: 256Mi
             requests:
               cpu: 0m
               memory: 128Mi
+              ephemeral-storage: 32Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
When a node is under disk pressure and wants to evict some pods, the first rule is for pods that use more resources than requested (https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction)

Requesting a bit here will prevent eviction of this pod, which is very unlikely to use much anyway.